### PR TITLE
update(Docker): use prod dependencies only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ WORKDIR /app
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
 RUN yarn build
+# Prune dev dependencies
+ RUN yarn install --production --frozen-lockfile
 
 # Production image, copy all the files and run next
 FROM node:14.15.1-alpine3.12 AS runner


### PR DESCRIPTION
`yarn install --production --frozen-lockfile` is somehow equivalent to `npm prune`

# Before
Final docker image size was 310MB 👎 
dockerize job takes 2m:59s 👍
insecure ❌ 

# After
Final docker image size becomes 179 MB 👍 
dockerize job takes 3m:43s 👎 
more secured ✅ 
