### PR TITLE
build & push using docker github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,57 +7,53 @@ on:
     branches: [ main ]
 
 jobs:
-  # build:
-  #   env:
-  #     NODE_VERSION: 14.15.1
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Use Node.js ${{ env.NODE_VERSION }}
-  #     uses: actions/setup-node@v2
-  #     with:
-  #       node-version: ${{ env.NODE_VERSION }}
-  #       cache: 'yarn'
-  #   - run: yarn install --frozen-lockfile
-  #   - run: yarn lint
-  #   - run: yarn build
-  #   - run: yarn test
+  build:
+    env:
+      NODE_VERSION: 14.15.1
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ env.NODE_VERSION }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+        cache: 'yarn'
+    - run: yarn install --frozen-lockfile
+    - run: yarn lint
+    - run: yarn build
+    - run: yarn test
 
   dockerize:
-    # needs: build
+    needs: build
     env: 
-      SHA: ${{github.event.pull_request.head.sha || github.sha}}
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
+      CONTAINER_REGISTRY: ghcr.io
+      CONTAINER_REPOSITORY: ${{ github.repository }}
     runs-on: ubuntu-20.04
     permissions:
       contents: read
       packages: write
     steps:
-    - name: Set SHA_SHORT
-      run: |
-        echo "SHA_SHORT=$(echo ${{env.SHA}} | cut -c1-7 )" >> $GITHUB_ENV
     - name: Log in to the Container registry
-      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      uses: docker/login-action@v1
       with:
-        registry: ${{ env.REGISTRY }}
+        registry: ${{ env.CONTAINER_REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      uses: docker/metadata-action@v3
       with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        images: ${{ env.CONTAINER_REGISTRY }}/${{ env.CONTAINER_REPOSITORY }}
         labels: |
           org.opencontainers.image.description=deployable image for my portfolio
-    - name: Build Docker image
-      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+    - name: Build Container image
+      uses: docker/build-push-action@v2
       with:
         push: false
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-    - name: Push Docker image
-      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        # tags: ${{ steps.meta.outputs.tags }}
+        # labels: ${{ steps.meta.outputs.labels }}
+    - name: Push Container image
+      uses: docker/build-push-action@v2
       with:
         push: ${{ github.event_name == 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
       uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        labels: |
+          org.opencontainers.image.description=deployable image for my portfolio
     - name: Build and push Docker image
       uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,6 @@ jobs:
     - name: Build and push Docker image
       uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
       with:
-        context: .
+        # context: .
         push: true
         tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{env.SHA_SHORT}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,15 @@ jobs:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         labels: |
           org.opencontainers.image.description=deployable image for my portfolio
-    - name: Build and push Docker image
+    - name: Build Docker image
       uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
       with:
-        push: true
+        push: false
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+    - name: Push Docker image
+      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      with:
+        push: ${{ github.event_name == 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,9 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         push: false
-        # tags: ${{ steps.meta.outputs.tags }}
-        # labels: ${{ steps.meta.outputs.labels }}
     - name: Push Container image
       uses: docker/build-push-action@v2
       with:
-        push: ${{ github.event_name == 'pull_request' }}
+        push: ${{ github.event_name == 'push' && github.branch }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,21 +7,21 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-    env:
-      NODE_VERSION: 14.15.1
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-        cache: 'yarn'
-    - run: yarn install --frozen-lockfile
-    - run: yarn lint
-    - run: yarn build
-    - run: yarn test
+  # build:
+  #   env:
+  #     NODE_VERSION: 14.15.1
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Use Node.js ${{ env.NODE_VERSION }}
+  #     uses: actions/setup-node@v2
+  #     with:
+  #       node-version: ${{ env.NODE_VERSION }}
+  #       cache: 'yarn'
+  #   - run: yarn install --frozen-lockfile
+  #   - run: yarn lint
+  #   - run: yarn build
+  #   - run: yarn test
 
   dockerize:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,6 @@ jobs:
     - name: Push Container image
       uses: docker/build-push-action@v2
       with:
-        push: ${{ github.event_name == 'push' && github.branch }}
+        push: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   #   - run: yarn test
 
   dockerize:
-    needs: build
+    # needs: build
     env: 
       SHA: ${{github.event.pull_request.head.sha || github.sha}}
       REGISTRY: ghcr.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,28 @@ jobs:
     needs: build
     env: 
       SHA: ${{github.event.pull_request.head.sha || github.sha}}
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
     steps:
     - name: Set SHA_SHORT
       run: |
         echo "SHA_SHORT=$(echo ${{env.SHA}} | cut -c1-7 )" >> $GITHUB_ENV
-    - uses: actions/checkout@v2
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag portfolio:${{env.SHA_SHORT}}
+    # - uses: actions/checkout@v2
+    # - name: Build the Docker image
+    #   run: docker build . --file Dockerfile --tag portfolio:${{env.SHA_SHORT}}
+    - name: Log in to the Container registry
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push Docker image
+      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      with:
+        context: .
+        push: true
+        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{env.SHA_SHORT}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,18 +37,20 @@ jobs:
     - name: Set SHA_SHORT
       run: |
         echo "SHA_SHORT=$(echo ${{env.SHA}} | cut -c1-7 )" >> $GITHUB_ENV
-    # - uses: actions/checkout@v2
-    # - name: Build the Docker image
-    #   run: docker build . --file Dockerfile --tag portfolio:${{env.SHA_SHORT}}
     - name: Log in to the Container registry
       uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
     - name: Build and push Docker image
       uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
       with:
-        # context: .
         push: true
-        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{env.SHA_SHORT}}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+LABEL org.opencontainers.image.description "deployable docker image of my portfolio"
 # Install dependencies only when needed
 FROM node:14.15.1-alpine3.12 AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Install dependencies only when needed
 FROM node:14.15.1-alpine3.12 AS deps
-LABEL org.opencontainers.image.description "deployable image for my portofolio"
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-LABEL org.opencontainers.image.description DESCRIPTION
 # Install dependencies only when needed
 FROM node:14.15.1-alpine3.12 AS deps
+LABEL org.opencontainers.image.description "deployable image for my portofolio"
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-LABEL org.opencontainers.image.description "deployable docker image of my portfolio"
 # Install dependencies only when needed
 FROM node:14.15.1-alpine3.12 AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+LABEL org.opencontainers.image.description DESCRIPTION
 # Install dependencies only when needed
 FROM node:14.15.1-alpine3.12 AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.


### PR DESCRIPTION
Closes #6 

A couple of things to call out here:

Previously, I was using docker commands on the shell of the runner, this is opens the door for exposing security secrets. Now I replaced all of that by using verified docker with actions to login, extract metadata , build and push the image.
Also I no longer need to figure out SHA for branch commit or PR merge commit since docker metadata action is taking care of that automatically.